### PR TITLE
Fix typo in `VueHighlightWords.ts`

### DIFF
--- a/src/VueHighlightWords.ts
+++ b/src/VueHighlightWords.ts
@@ -117,7 +117,7 @@ VueHighlightWordsImpl.props = {
   autoEscape: Boolean,
   caseSensitive: {
     type: Boolean,
-    defualt: false,
+    default: false,
   },
   findChunks: Function,
   custom: {


### PR DESCRIPTION
Fix the spelling of `default`; was misspelled as `defualt`